### PR TITLE
Adicionando links de referência: Stylus e Rupture

### DIFF
--- a/meetups/11.md
+++ b/meetups/11.md
@@ -31,4 +31,6 @@ Tem algum link relacionado ao tema ou que foi discutido no meetup? Abre um PR e 
 * [kibe](https://github.com/woliveiras/kibe)
 * [Twitter Jeff Escalante](https://twitter.com/jescalan)
 * [Maps](http://codepen.io/jakealbaugh/post/using-sass-functions-to-access-complex-variable-maps)
+* [Stylus](https://learnboost.github.io/stylus/)
 * [Jeet Grid](http://jeet.gs/)
+* [Rupture: Media Queries with Stylus](https://jenius.github.io/rupture/)


### PR DESCRIPTION
Apenas adicionando os links do Stylus e do Rupture, presentes na talk do Vitor Mendrone. :+1: 
